### PR TITLE
Introduced argument parsing library in order to introduce various command line options

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Easily run git commands in multiple subdirectories.
 
 ##How to use GitAll
 
-    usage: gitall [-h] [-Ï <file>] [-n] [-q] [-v] command
+    usage: gitall [-h] [-I <includefile>] [-n] [-q] [-v] command
 
     Perform a git command on multiple git repositories in subfolders
 

--- a/gitall
+++ b/gitall
@@ -3,6 +3,7 @@
 import os
 import sys
 import argparse
+
 REPO_COLOR = '\033[95m'
 DASH_COLOR = '\033[91m'
 COLOR_STOP = '\033[0m'
@@ -51,7 +52,10 @@ def main():
 
 	for gitDirectory in gitDirectories:
 		os.chdir(gitDirectory)
-		pinkrepo = REPO_COLOR + os.path.relpath(gitDirectory, localDir) + COLOR_STOP
+		if os.name == 'nt':
+			pinkrepo = os.path.relpath(gitDirectory, localDir)
+		else:
+			pinkrepo = REPO_COLOR + os.path.relpath(gitDirectory, localDir) + COLOR_STOP
 		repooutput = v(1, 'Current repo:') + (pinkrepo,) + v(2," in ( "+os.path.abspath('.')+" )")
 		verboseprint(-1, *repooutput)
 		os.system(commandstring)
@@ -91,7 +95,10 @@ def printDelimiter(show):
 		dash = "#"
 	if show:
 		dashes = dash * 80
-		print DASH_COLOR + dashes + COLOR_STOP
+		if os.name == 'nt':
+			print dashes
+		else:
+			print DASH_COLOR + dashes + COLOR_STOP
 
 if __name__ == '__main__':
 	main()


### PR DESCRIPTION
Hi Walter.
I decided one day, that I would love to have a --quiet/-q option to reduce output, especially when I do git commands that only output one line (like printing current branch). 
I found that the 'state of the art' argument parser library in python seems to be argparse, so I went with that, and it inspired me to add a few more options along the way. (I.e. more verbosity options and the --raw for occasional non-git commands). A co-worker (Simon) started using it, and needed a way to limit which repos were affected. He helped by adding the --include-from option and a few improvements to make it work on his windows machine.
I named the option --include-from (-I) as I plan on adding --include (-i) and --exclude (for specifying on the command line) later, and I thought that it would be nice to keep the naming of the switches in line with tools like rsync.

I hope you like the changes, and hope that it makes it easier to add more options in the future (without the script spiraling out of hand in complexity).
If you have any suggestions for new useful options, let me know, and I might find the time to add them as well.
Regards Jan
