### PR TITLE
added --date parameter to checkout multiple git repositories by date …

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@ Easily run git commands across all your repositories.
 
 ##How to use GitAll
 
-    usage: gitall [-h] [-I <includefile>] [-n] [-q] [-v] command
+    usage: gitall [-h] [-I includefile] [-i include] [-e exclude] [-d date] [-n]
+                  [-q] [-v] [-r]
+                  ...
 
-    Perform a git command on multiple git repositories in subfolders
+    Perform a git operation on multiple git repositories in subfolders
 
     positional arguments:
       operation             The git operation to perform on each repository, i.e.
@@ -15,7 +17,7 @@ Easily run git commands across all your repositories.
 
     optional arguments:
       -h, --help            show this help message and exit
-      -I <includefile>, --include-from <includefile>
+      -I includefile, --include-from includefile
                             Read repositories to operate on from specified file.
       -i include, --include include
                             Specify comma-separated list of repositories to use.
@@ -23,6 +25,10 @@ Easily run git commands across all your repositories.
       -e exclude, --exclude exclude
                             Specify comma-separated list of repositories to
                             exclude. Applied after auto-detect or include(-file)
+      -d date, --date date  Specify checkout by date instead of ref. This
+                            parameter must be used with gitall checkout <branch>.
+                            The date format is YYYY-MM-DD HH:MM:SS or a shorter
+                            format. See also the date format used by git rev-list
       -n, --noseparator     Suppress printing of separator line between
                             repositories.
       -q, --quiet           decrease output verbosity. Repeat for more silence, or
@@ -33,7 +39,8 @@ Easily run git commands across all your repositories.
                             not a git 'sub'-command. Example: gitall --raw cat
                             .gitignore
 
-    NOTE: --quiet and --verbose cancel out each other. e.g. '-qqv' = '-q'
+    NOTE: --quiet and --verbose cancel each other out one by one so '-qqv' gives
+    the same result as '-q'
 
 ##Installing GitAll
 

--- a/gitall
+++ b/gitall
@@ -3,6 +3,9 @@
 import os
 import sys
 import argparse
+import re
+import subprocess
+
 
 REPO_COLOR = '\033[95m'
 DASH_COLOR = '\033[91m'
@@ -19,6 +22,8 @@ def main():
 		help='Specify comma-separated list of repositories to use. Suppresses automatic repo detection')
 	parser.add_argument('-e', '--exclude', metavar='exclude', dest='exclude', type=str,
 		help="Specify comma-separated list of repositories to exclude. Applied after auto-detect or include(-file)")
+	parser.add_argument('-d', '--date', metavar='date', dest='date', type=str,
+		help="Specify checkout by date instead of ref. This parameter must be used with gitall checkout <branch>. The date format is YYYY-MM-DD HH:MM:SS or a shorter format. See also the date format used by git rev-list")
 	parser.add_argument('-n', '--noseparator', dest='sep', action='store_false', default=True,
 		help='Suppress printing of separator line between repositories.')
 	parser.add_argument('-q', '--quiet', action="count", default=0,
@@ -74,7 +79,29 @@ def main():
 			pinkrepo = REPO_COLOR + os.path.relpath(fullDir, localDir) + COLOR_STOP
 		repooutput = v(1, 'Current repo:') + (pinkrepo,) + v(2," in ( "+os.path.abspath('.')+" )")
 		verboseprint(-1, *repooutput)
-		os.system(commandstring)
+		#if date is specified, then use git rev-list to get the sha from the date
+		if args.date:
+			regex = re.compile('\w+')
+			match = regex.findall(commandstring)
+			command = match[1]
+			#check if a branch was specified
+			try:
+				branch = match[2]
+			except IndexError:
+				sys.exit("--date must be used with git checkout <branch>")
+			#check if the command was git checkout
+			if ( not command == 'checkout'):
+				sys.exit("--date must be used with git checkout <branch>")
+			else:
+				#use git rev-list to get most recent sha hash before specified date
+				revparameters = ["git","rev-list", "-1", "--before="+args.date, branch]
+				revcommand = subprocess.Popen(revparameters, stdout=subprocess.PIPE)
+				(sha, err) = revcommand.communicate()
+				#construct a new datecommandstring (as the commandstring will be parsed in the loop for other repositories)
+				datecommandstring = "git "+command +" "+sha
+			os.system(datecommandstring)
+		else:
+			os.system(commandstring)
 		printDelimiter(verbosity >=0 and args.sep)
 
 def convert_commasep_to_list(include):


### PR DESCRIPTION
If you have several components for some software located in multiple repositories, it is sometimes handy to be able to checkout all of the components from the same date/time (so they match).
This is usually a pretty annoying thing, because you need to run git rev-list for each repository to get the correct sha to checkout.
The gitall --date=<some data and time> checkout <some branch> can now handle this.
